### PR TITLE
Emulator code refactored

### DIFF
--- a/js/commandController.js
+++ b/js/commandController.js
@@ -10,7 +10,7 @@
 $(document).ready(function(){
     console.log("Command Controller loaded");
     uiDisable(true)
-    emulatorClass = new Emulator();
+    emulatorClass = new Emulator({logger: displayLog});
 });
 
 // - Request a port and open an asynchronous connection, 
@@ -95,29 +95,22 @@ async function readLoop() {
 }
 
 function writeToStream(...lines) {
-    // Stops data being written to nonexistent port if using emulator
-    if (port) {
-        const writer = outputStream.getWriter();
-        lines.forEach((line) => {
-            writer.write('<' + line + '>' + '\n');
-            console.log('<' + line + '>' + '\n')
-            if (line == "\x03" || line == "echo(false);") {
-                
-            } else {
-                displayLog('[SEND]'+line.toString());
-            }
-        });
-        writer.releaseLock();
-    } else {
-        lines.forEach((line) => {
-            displayLog('[SEND] '+line.toString());
-            const packet = `<${line}>`;
-            const message = emulatorClass.write(packet)
-            console.log(packet + '\n')
-            displayLog('[RECEIVE] '+message);
-        });
-    }
+  // Stops data being written to nonexistent port if using emulator
+  let stream = emulatorClass
+  if (port) {
+    stream = outputStream.getWriter();
+  }
 
+  lines.forEach((line) => {
+      if (line == "\x03" || line == "echo(false);") {
+
+      } else {
+          displayLog('[SEND]'+line.toString());
+      }
+      const packet = `<${line}>\n`;
+      stream.write(packet)
+      console.log(packet)
+  });
 }
 
 // Transformer for the Web Serial API. Data comes in as a stream so we

--- a/js/commandController.js
+++ b/js/commandController.js
@@ -10,6 +10,7 @@
 $(document).ready(function(){
     console.log("Command Controller loaded");
     uiDisable(true)
+    emulatorClass = new Emulator();
 });
 
 // - Request a port and open an asynchronous connection, 
@@ -110,8 +111,9 @@ function writeToStream(...lines) {
     } else {
         lines.forEach((line) => {
             displayLog('[SEND] '+line.toString());
-            message = emulator('<' + line + '>')
-            console.log('<' + line + '>' + '\n')
+            const packet = `<${line}>`;
+            const message = emulatorClass.write(packet)
+            console.log(packet + '\n')
             displayLog('[RECEIVE] '+message);
         });
     }

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -9,10 +9,9 @@
 */
 
 function emulator(packet) {
-  let lastMessage;
-  var turnouts = [];
+  const turnouts = [];
 
-  if (packet == "<credits>") {
+  if (packet === "<credits>") {
     console.log("Credits")
     return credits()
   }
@@ -24,18 +23,15 @@ function emulator(packet) {
   switch (packetKey) {
     // Cab control
     case ("t"):
-      lastMessage = 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2)
-      return lastMessage;
+      return 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2)
 
     // Track power off
     case ('0') :
-      lastMessage = 'p0';
-      return lastMessage;
+      return 'p0';
 
     // Track power on
     case ('1'):
-      lastMessage = 'p1';
-      return lastMessage;
+      return 'p1';
 
     // New cab functions
     case ('F'):
@@ -47,10 +43,11 @@ function emulator(packet) {
 
     // Turnouts
     case ('T'): //Not fully finished
-      if (splitPacket.length == 4) {
+      let returnList;
+      if (splitPacket.length === 4) {
         turnouts.push({id: splitPacket[1], address: splitPacket[2], subaddress: splitPacket[3], throw: 0})
         return '<O>';
-      } else if (splitPacket.length == 2) {
+      } else if (splitPacket.length === 2) {
         var i;
         for (i = 0; i < turnouts.length; i++) {
           if (turnouts[i]['id'] == splitPacket[1].substring(0, splitPacket[1].length - 1)) {
@@ -59,7 +56,7 @@ function emulator(packet) {
           }
         }
         return 'X';
-      } else if (splitPacket.length == 1) {
+      } else if (splitPacket.length === 1) {
         returnList = [];
         if (turnouts.length > 0) {
           for (i = 0; i < turnouts.length; i++) {

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -25,14 +25,16 @@ function cabFunctionCommand(packet, legacy = false) {
   return NaN;
 }
 
-function turnoutCommand(packet) {
-  const splitPacket = packet.split(" ");
-  const turnouts = [];
+function turnoutCommand(packet, turnouts = []) {
+  const splitPacket = removeControlCharacters(packet).split(" ");
   let returnList;
+
   if (splitPacket.length === 4) {
+    // Adds a Turnout
     turnouts.push({id: splitPacket[1], address: splitPacket[2], subaddress: splitPacket[3], throw: 0})
     return '<O>';
   } else if (splitPacket.length === 2) {
+    // Removes a Turnout
     var i;
     for (i = 0; i < turnouts.length; i++) {
       if (turnouts[i]['id'] == splitPacket[1].substring(0, splitPacket[1].length - 1)) {
@@ -42,6 +44,7 @@ function turnoutCommand(packet) {
     }
     return 'X';
   } else if (splitPacket.length === 1) {
+    // Reads Turnouts
     returnList = [];
     if (turnouts.length > 0) {
       for (i = 0; i < turnouts.length; i++) {
@@ -53,10 +56,16 @@ function turnoutCommand(packet) {
   }
 }
 
+function removeControlCharacters(packet) {
+  return [...packet].filter(char => !["<", ">"].includes(char)).join("")
+}
+
 function extractPacketKey(packet) {
-  const cleanedPacket = [...packet].filter(char => !["<", ">"].includes(char))
+  const cleanedPacket = [...removeControlCharacters(packet)]
   return cleanedPacket.find(char => char !== " ");
 }
+
+let turnouts = []
 
 function emulator(packet) {
   if (packet === "<credits>") {
@@ -89,7 +98,7 @@ function emulator(packet) {
 
     // Turnouts
     case ('T'): //Not fully finished
-      return turnoutCommand(packet);
+      return turnoutCommand(packet, turnouts);
 
     default:
       break;

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -8,6 +8,8 @@
     file manages the correct response that a Command Station would provide.
 */
 /**
+ * Utility function can be moved when we can import files
+ * @description Removes control characters "<", ">" and "\n"
  * @param {string} packet
  * @return {string}
  */
@@ -16,6 +18,8 @@ function removeControlCharacters(packet) {
 }
 
 /**
+ * Utility function can be moved when we can import files
+ * @description Finds the first non-blank character after control characters are removed
  * @param {string} packet
  * @return {string}
  */

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -8,23 +8,25 @@
     file manages the correct response that a Command Station would provide.
 */
 
-function cabControlCommand(splitPacket) {
+function cabControlCommand(packet) {
+  const splitPacket = packet.split(" ");
   return 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2);
 }
 
-function powerOffCommand(_splitPacket) {
+function powerOffCommand(packet) {
   return 'p0';
 }
 
-function powerOnCommand(_splitPacket) {
+function powerOnCommand(packet) {
   return 'p1';
 }
 
-function cabFunctionCommand(_splitPacket, legacy = false) {
+function cabFunctionCommand(packet, legacy = false) {
   return NaN;
 }
 
-function turnoutCommand(splitPacket) {
+function turnoutCommand(packet) {
+  const splitPacket = packet.split(" ");
   const turnouts = [];
   let returnList;
   if (splitPacket.length === 4) {
@@ -51,6 +53,10 @@ function turnoutCommand(splitPacket) {
   }
 }
 
+function extractPacketKey(packet) {
+  const cleanedPacket = [...packet].filter(char => !["<", ">"].includes(char))
+  return cleanedPacket.find(char => char !== " ");
+}
 
 function emulator(packet) {
   if (packet === "<credits>") {
@@ -58,33 +64,34 @@ function emulator(packet) {
     return credits()
   }
 
-  const cleanedPacket = [...packet].filter(char => !["<", ">"].includes(char))
-  let packetKey = cleanedPacket.find(char => char !== " ");
+  let packetKey = extractPacketKey(packet);
 
-  const splitPacket = packet.split(" ");
   switch (packetKey) {
     // Cab control
     case ("t"):
-      return cabControlCommand(splitPacket)
+      return cabControlCommand(packet)
 
     // Track power off
     case ('0') :
-      return powerOffCommand(splitPacket);
+      return powerOffCommand(packet);
 
     // Track power on
     case ('1'):
-      return powerOnCommand(splitPacket);
+      return powerOnCommand(packet);
 
     // New cab functions
     case ('F'):
-      return cabFunctionCommand(splitPacket);
+      return cabFunctionCommand(packet);
 
     // Legacy cab functions
     case ('f'):
-      return cabFunctionCommand(splitPacket, true);
+      return cabFunctionCommand(packet, true);
 
     // Turnouts
     case ('T'): //Not fully finished
-      return turnoutCommand(splitPacket);
+      return turnoutCommand(packet);
+
+    default:
+      break;
   }
 }

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -8,9 +8,51 @@
     file manages the correct response that a Command Station would provide.
 */
 
-function emulator(packet) {
-  const turnouts = [];
+function cabControlCommand(splitPacket) {
+  return 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2);
+}
 
+function powerOffCommand(_splitPacket) {
+  return 'p0';
+}
+
+function powerOnCommand(_splitPacket) {
+  return 'p1';
+}
+
+function cabFunctionCommand(_splitPacket, legacy = false) {
+  return NaN;
+}
+
+function turnoutCommand(splitPacket) {
+  const turnouts = [];
+  let returnList;
+  if (splitPacket.length === 4) {
+    turnouts.push({id: splitPacket[1], address: splitPacket[2], subaddress: splitPacket[3], throw: 0})
+    return '<O>';
+  } else if (splitPacket.length === 2) {
+    var i;
+    for (i = 0; i < turnouts.length; i++) {
+      if (turnouts[i]['id'] == splitPacket[1].substring(0, splitPacket[1].length - 1)) {
+        turnouts.splice(i, 1);
+        return 'O';
+      }
+    }
+    return 'X';
+  } else if (splitPacket.length === 1) {
+    returnList = [];
+    if (turnouts.length > 0) {
+      for (i = 0; i < turnouts.length; i++) {
+        returnList.push('H ' + turnouts[i]['id'] + ' ' + turnouts[i]['address'] + ' ' + turnouts[i]['subaddress'] + ' ' + turnouts[i]['throw']);
+      }
+      return returnList;
+    }
+    return 'X';
+  }
+}
+
+
+function emulator(packet) {
   if (packet === "<credits>") {
     console.log("Credits")
     return credits()
@@ -23,48 +65,26 @@ function emulator(packet) {
   switch (packetKey) {
     // Cab control
     case ("t"):
-      return 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2)
+      return cabControlCommand(splitPacket)
 
     // Track power off
     case ('0') :
-      return 'p0';
+      return powerOffCommand(splitPacket);
 
     // Track power on
     case ('1'):
-      return 'p1';
+      return powerOnCommand(splitPacket);
 
     // New cab functions
     case ('F'):
-      return NaN;
+      return cabFunctionCommand(splitPacket);
 
     // Legacy cab functions
     case ('f'):
-      return NaN;
+      return cabFunctionCommand(splitPacket, true);
 
     // Turnouts
     case ('T'): //Not fully finished
-      let returnList;
-      if (splitPacket.length === 4) {
-        turnouts.push({id: splitPacket[1], address: splitPacket[2], subaddress: splitPacket[3], throw: 0})
-        return '<O>';
-      } else if (splitPacket.length === 2) {
-        var i;
-        for (i = 0; i < turnouts.length; i++) {
-          if (turnouts[i]['id'] == splitPacket[1].substring(0, splitPacket[1].length - 1)) {
-            turnouts.splice(i, 1);
-            return 'O';
-          }
-        }
-        return 'X';
-      } else if (splitPacket.length === 1) {
-        returnList = [];
-        if (turnouts.length > 0) {
-          for (i = 0; i < turnouts.length; i++) {
-            returnList.push('H ' + turnouts[i]['id'] + ' ' + turnouts[i]['address'] + ' ' + turnouts[i]['subaddress'] + ' ' + turnouts[i]['throw']);
-          }
-          return returnList;
-        }
-        return 'X';
-      }
+      return turnoutCommand(splitPacket);
   }
 }

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -12,7 +12,7 @@
  * @return {string}
  */
 function removeControlCharacters(packet) {
-  return [...packet].filter(char => !["<", ">"].includes(char)).join("")
+  return [...packet].filter(char => !["<", ">", "\n"].includes(char)).join("")
 }
 
 /**
@@ -25,8 +25,9 @@ function extractPacketKey(packet) {
 }
 
 class Emulator {
-  constructor() {
+  constructor({logger}) {
     this.turnoutEmulator = new TurnoutEmulator()
+    this.logger = logger
   }
 
   /**
@@ -43,27 +44,34 @@ class Emulator {
     switch (packetKey) {
       // Cab control
       case ("t"):
-        return this.#cabControlCommand(packet)
+        this.logger('[RECEIVE] '+ this.#cabControlCommand(packet))
+        break;
 
       // Track power off
       case ('0') :
-        return this.#powerOffCommand(packet);
+        this.logger('[RECEIVE] '+ this.#powerOffCommand(packet));
+        break;
 
       // Track power on
       case ('1'):
-        return this.#powerOnCommand(packet);
+        this.logger('[RECEIVE] '+ this.#powerOnCommand(packet));
+        break;
 
       // New cab functions
       case ('F'):
-        return this.#cabFunctionCommand(packet);
+        this.logger('[RECEIVE] '+  this.#cabFunctionCommand(packet));
+        break;
 
       // Legacy cab functions
       case ('f'):
-        return this.#cabFunctionCommand(packet, true);
+
+        this.logger('[RECEIVE] '+  this.#cabFunctionCommand(packet, true));
+        break;
 
       // Turnouts
       case ('T'): //Not fully finished
-        return this.#turnoutCommand(packet, this.turnoutEmulator);
+        this.logger('[RECEIVE] '+  this.#turnoutCommand(packet, this.turnoutEmulator))
+        break
 
       default:
         break;

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -8,66 +8,66 @@
     file manages the correct response that a Command Station would provide.
 */
 
-let lastMessage;
-var turnouts = [];
 function emulator(packet) {
-    if (packet == "<credits>") {
-        console.log("Credits")
-        return credits()
-    } else {
-    packetKey = packet[1];
-    if (packetKey == ' ') {
-        packetKey = packet[2];
-    }
-    packet = packet.split(" ");
-    switch (packetKey) {
-        // Cab control
-        case ("t"):
-            lastMessage = 'T 1 '+ packet[3] + ' ' + packet[4].substring(0, packet[4].length-2)
-            return lastMessage;
-            
-        // Track power off
-        case ('0') :
-            lastMessage = 'p0';
-            return lastMessage;
+  let lastMessage;
+  var turnouts = [];
 
-        // Track power on
-        case ('1'):
-            lastMessage = 'p1';
-            return lastMessage;
+  if (packet == "<credits>") {
+    console.log("Credits")
+    return credits()
+  }
 
-        // New cab functions
-        case ('F'):
-            return NaN;
-        
-        // Legacy cab functions
-        case ('f'):
-            return NaN;
-        
-        // Turnouts
-        case ('T'): //Not fully finished
-            if (packet.length == 4) {
-                turnouts.push({id: packet[1], address: packet[2], subaddress: packet[3], throw: 0})
-                return '<O>';
-            } else if (packet.length == 2) {
-                var i;
-                for (i=0; i<turnouts.length; i++ ) {
-                    if (turnouts[i]['id'] == packet[1].substring(0, packet[1].length-1)) {
-                        turnouts.splice(i, 1);
-                        return 'O';
-                    }
-                }
-                return 'X';
-            } else if (packet.length == 1) {
-                returnList = [];
-                if (turnouts.length > 0) {
-                    for (i=0; i<turnouts.length; i++){
-                        returnList.push('H '+turnouts[i]['id']+' '+turnouts[i]['address']+' '+turnouts[i]['subaddress']+' '+turnouts[i]['throw']);
-                    }
-                return returnList;
-                }
-                return 'X';
-            }
+  const cleanedPacket = [...packet].filter(char => !["<", ">"].includes(char))
+  let packetKey = cleanedPacket.find(char => char !== " ");
+
+  const splitPacket = packet.split(" ");
+  switch (packetKey) {
+    // Cab control
+    case ("t"):
+      lastMessage = 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2)
+      return lastMessage;
+
+    // Track power off
+    case ('0') :
+      lastMessage = 'p0';
+      return lastMessage;
+
+    // Track power on
+    case ('1'):
+      lastMessage = 'p1';
+      return lastMessage;
+
+    // New cab functions
+    case ('F'):
+      return NaN;
+
+    // Legacy cab functions
+    case ('f'):
+      return NaN;
+
+    // Turnouts
+    case ('T'): //Not fully finished
+      if (splitPacket.length == 4) {
+        turnouts.push({id: splitPacket[1], address: splitPacket[2], subaddress: splitPacket[3], throw: 0})
+        return '<O>';
+      } else if (splitPacket.length == 2) {
+        var i;
+        for (i = 0; i < turnouts.length; i++) {
+          if (turnouts[i]['id'] == splitPacket[1].substring(0, splitPacket[1].length - 1)) {
+            turnouts.splice(i, 1);
+            return 'O';
+          }
         }
-    }
+        return 'X';
+      } else if (splitPacket.length == 1) {
+        returnList = [];
+        if (turnouts.length > 0) {
+          for (i = 0; i < turnouts.length; i++) {
+            returnList.push('H ' + turnouts[i]['id'] + ' ' + turnouts[i]['address'] + ' ' + turnouts[i]['subaddress'] + ' ' + turnouts[i]['throw']);
+          }
+          return returnList;
+        }
+        return 'X';
+      }
+  }
 }

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -7,100 +7,169 @@
     Allows the software to operate without a Command Station attached. This 
     file manages the correct response that a Command Station would provide.
 */
-
-function cabControlCommand(packet) {
-  const splitPacket = packet.split(" ");
-  return 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2);
-}
-
-function powerOffCommand(packet) {
-  return 'p0';
-}
-
-function powerOnCommand(packet) {
-  return 'p1';
-}
-
-function cabFunctionCommand(packet, legacy = false) {
-  return NaN;
-}
-
-function turnoutCommand(packet, turnouts = []) {
-  const splitPacket = removeControlCharacters(packet).split(" ");
-  let returnList;
-
-  if (splitPacket.length === 4) {
-    // Adds a Turnout
-    turnouts.push({id: splitPacket[1], address: splitPacket[2], subaddress: splitPacket[3], throw: 0})
-    return '<O>';
-  } else if (splitPacket.length === 2) {
-    // Removes a Turnout
-    var i;
-    for (i = 0; i < turnouts.length; i++) {
-      if (turnouts[i]['id'] == splitPacket[1].substring(0, splitPacket[1].length - 1)) {
-        turnouts.splice(i, 1);
-        return 'O';
-      }
-    }
-    return 'X';
-  } else if (splitPacket.length === 1) {
-    // Reads Turnouts
-    returnList = [];
-    if (turnouts.length > 0) {
-      for (i = 0; i < turnouts.length; i++) {
-        returnList.push('H ' + turnouts[i]['id'] + ' ' + turnouts[i]['address'] + ' ' + turnouts[i]['subaddress'] + ' ' + turnouts[i]['throw']);
-      }
-      return returnList;
-    }
-    return 'X';
-  }
-}
-
+/**
+ * @param {string} packet
+ * @return {string}
+ */
 function removeControlCharacters(packet) {
   return [...packet].filter(char => !["<", ">"].includes(char)).join("")
 }
 
+/**
+ * @param {string} packet
+ * @return {string}
+ */
 function extractPacketKey(packet) {
   const cleanedPacket = [...removeControlCharacters(packet)]
   return cleanedPacket.find(char => char !== " ");
 }
 
-let turnouts = []
-
-function emulator(packet) {
-  if (packet === "<credits>") {
-    console.log("Credits")
-    return credits()
+class Emulator {
+  constructor() {
+    this.turnoutEmulator = new TurnoutEmulator()
   }
 
-  let packetKey = extractPacketKey(packet);
+  /**
+   * @param {string} packet
+   */
+  write(packet) {
+    if (packet === "<credits>") {
+      console.log("Credits")
+      return credits()
+    }
 
-  switch (packetKey) {
-    // Cab control
-    case ("t"):
-      return cabControlCommand(packet)
+    let packetKey = extractPacketKey(packet);
 
-    // Track power off
-    case ('0') :
-      return powerOffCommand(packet);
+    switch (packetKey) {
+      // Cab control
+      case ("t"):
+        return this.#cabControlCommand(packet)
 
-    // Track power on
-    case ('1'):
-      return powerOnCommand(packet);
+      // Track power off
+      case ('0') :
+        return this.#powerOffCommand(packet);
 
-    // New cab functions
-    case ('F'):
-      return cabFunctionCommand(packet);
+      // Track power on
+      case ('1'):
+        return this.#powerOnCommand(packet);
 
-    // Legacy cab functions
-    case ('f'):
-      return cabFunctionCommand(packet, true);
+      // New cab functions
+      case ('F'):
+        return this.#cabFunctionCommand(packet);
 
-    // Turnouts
-    case ('T'): //Not fully finished
-      return turnoutCommand(packet, turnouts);
+      // Legacy cab functions
+      case ('f'):
+        return this.#cabFunctionCommand(packet, true);
 
-    default:
-      break;
+      // Turnouts
+      case ('T'): //Not fully finished
+        return this.#turnoutCommand(packet, this.turnoutEmulator);
+
+      default:
+        break;
+    }
+  }
+
+  /**
+   * @param {string} packet
+   * @return {string}
+   */
+  #cabControlCommand(packet) {
+    const splitPacket = packet.split(" ");
+    return 'T 1 ' + splitPacket[3] + ' ' + splitPacket[4].substring(0, splitPacket[4].length - 2);
+  }
+
+  /**
+   * @param {string} packet
+   * @return {string}
+   */
+  #powerOffCommand(packet) {
+    return 'p0';
+  }
+
+  /**
+   * @param {string} packet
+   * @return {string}
+   */
+  #powerOnCommand(packet) {
+    return 'p1';
+  }
+
+  /**
+   * @param {string} packet
+   * @param {boolean} legacy
+   * @return number
+   */
+  #cabFunctionCommand(packet, legacy = false) {
+    return NaN;
+  }
+
+  /**
+   * @param {string} packet
+   * @param {TurnoutEmulator} turnoutEmulator
+   * @return {string}
+   */
+  #turnoutCommand(packet, turnoutEmulator = new TurnoutEmulator()) {
+    const splitPacket = removeControlCharacters(packet).split(" ");
+
+    if (splitPacket.length === 4) {
+      // Adds a Turnout
+      return turnoutEmulator.addTurnout(new Turnout(packet))
+    } else if (splitPacket.length === 2) {
+      // Removes a Turnout
+      return turnoutEmulator.removeTurnout(splitPacket[1])
+    } else if (splitPacket.length === 1) {
+      // Reads Turnouts
+      return turnoutEmulator.turnouts
+    }
+  }
+}
+
+class TurnoutEmulator {
+  /**
+   * @type {[]}
+   */
+  #turnouts = []
+
+  /**
+   * @return {string|string[]}
+   */
+  get turnouts() {
+    if (!this.#turnouts.length) {
+      return 'X'
+    }
+
+    return this.#turnouts.map(turnout => `H ${turnout.id} ${turnout.address} ${turnout.subaddress} ${turnout.thrown}`)
+  }
+
+  /**
+   * @param {*} turnout
+   * @return {string}
+   */
+  addTurnout(turnout) {
+    this.#turnouts = [...this.#turnouts, turnout]
+    console.log(this.#turnouts);
+    return '<O>';
+  }
+
+  /**
+   * @param {string} turnoutId
+   * @return {string}
+   */
+  removeTurnout(turnoutId) {
+    this.#turnouts = this.#turnouts.filter(turnout => turnout.id !== turnoutId);
+    console.log(this.#turnouts);
+    return 'O';
+  }
+}
+
+class Turnout {
+  constructor(packet) {
+    let [_key, id, address, subaddress] = removeControlCharacters(packet).split(" ");
+
+    this.id = id
+    this.address = address
+    this.subaddress = subaddress
+    this.thrown = 0
   }
 }


### PR DESCRIPTION
### What?

I have added/removed/altered:
- [x] Refactored `function emulator()` into a class `Emulator`
- [x] Refactored `writeToStream`
- [x] Added a `TurnoutsEmulator` class
- [x] Added a `Turnout` class

### Why?

I am doing this because:
- The main goal was to make the Emulator easier to read.
- Emulator class now behaves in a similar manner to the `outputstream` making switching between Emulator and Serial outputs more seamless.
- A clear separation of responsibilities has been created between Emulator and Turnout Emulator
- These changes help pave the way towards testable, modularised code.

### Acceptance Criteria

I can call this done when:
- [x] Emulator behaves as it did previously

### Deployment risks
- Some assumptions have been made about the `packet` variable.
  - For Turnouts, the `subaddress` previously included the `>` character. This has been removed in this PR.
- All new code has been written using `ES6` syntax. This is widely [supported](https://caniuse.com/?search=es6) by modern browsers.