### PR TITLE
Fixes error when using map select (autocomplete)

### DIFF
--- a/js/addloco.js
+++ b/js/addloco.js
@@ -127,14 +127,11 @@ $(document).ready(function(){
 });
 
 function getPreparedMaps() {
-    maps = getMapData();
-    if (maps != null){
-        maps.unshift({
-            mname: "Default",
-            fnData: {},
-        });
+    const defaultMap = {
+      mname: "Default",
+      fnData: {},
     }
-    return maps;
+    return [defaultMap, ...getMapData()];
 }
 
 /** Reference Map Structure 

--- a/js/exwebthrottle.js
+++ b/js/exwebthrottle.js
@@ -914,19 +914,18 @@ $(document).ready(function(){
 
 });
 
-function setFunctionMaps(){
-    maps = getMapData();
-    if (maps != null) {
-        maps.unshift({
-        mname: "Default",
-        fnData: {},
-        });
-    }
-    $("#function-mappings").empty();
-    $("#function-mappings").append("<li class='map-name' map-val='Default'>Default</li>");
-    $.each(getMapData(), function () {
-      $("#function-mappings").append("<li class='map-name' map-val=" + this.mname + ">" + this.mname + "</li>");
-    });
+function setFunctionMaps() {
+  const defaultMap = {
+    mname: "Default",
+    fnData: {},
+  }
+  const maps = [defaultMap, ...getMapData()];
+
+  $("#function-mappings").empty();
+  maps.forEach(map => {
+    const name = map.mname
+    $("#function-mappings").append(`<li class='map-name' map-val=${name}>${name}</li>`);
+  })
 }
 
 function hideWindows(){

--- a/js/storageController.js
+++ b/js/storageController.js
@@ -189,9 +189,9 @@ $(document).ready(function(){
 function loadmaps(){
   $("#select-map").empty();
   $("#select-map").append($("<option />").val("default").text("Default"));
-  $.each(getMapData(), function() {
-    $("#select-map").append($("<option />").val(this.mname).text(this.mname));
-  });
+  getMapData().forEach(map => {
+    $("#select-map").append($("<option />").val(map.mname).text(map.mname));
+  })
 }
 
 // Load button layout of selected Map
@@ -297,35 +297,34 @@ function editMap(){
 // Verify if the given Map data already exists and replace it
 // Or Create new map data and inserts it into local storage object
 // Finally Saves the Data into Local storage */
-function setMapData(mapdata){
-  if (typeof(Storage) !== "undefined") {
-    curmapdata = []; 
-    smapdata = JSON.parse(window.localStorage.getItem('mapData'));
-    if(!smapdata){
-        curmapdata.push(mapdata);
-        window.localStorage.setItem('mapData', JSON.stringify(curmapdata));
-    }else{
-     if (ifExists(mapdata.mname)) {
-       smapdata.find(function (item, i) {
-         if (item.mname == mapdata.mname) {
-           item.fnData = mapdata.fnData;
-         }
-       });
-     } else {
-       smapdata.push(mapdata);
-     }
-      window.localStorage.setItem('mapData', JSON.stringify(smapdata));
-    }
-    loadmaps();
-    setFunctionMaps();
-    loadMapData(mapdata.mname);
-    $("#select-map").val(mapdata.mname).trigger("change");
+function setMapData(mapdata) {
+  if (typeof Storage === "undefined") {
+    return;
   }
+
+  const smapdata = getMapData()
+
+  if (ifExists(mapdata.mname)) {
+    smapdata.find(function (item, i) {
+      if (item.mname == mapdata.mname) {
+        item.fnData = mapdata.fnData;
+      }
+    });
+  } else {
+    smapdata.push(mapdata);
+  }
+  window.localStorage.setItem('mapData', JSON.stringify(smapdata));
+
+  loadmaps();
+  setFunctionMaps();
+  loadMapData(mapdata.mname);
+  $("#select-map").val(mapdata.mname).trigger("change");
+
 }
 
 //Returns the Map data of given Map name
 function getStoredMapData(name){
-  data = JSON.parse(window.localStorage.getItem('mapData'));
+  const data = getMapData();
   if(data !=null){
     return data.find(function(item, i){
       if(item.mname == name){
@@ -353,7 +352,7 @@ function deleteFuncData(name){
   if (r == true) {
     if (typeof(Storage) !== "undefined") {
       curmapdata = []; 
-      data = JSON.parse(window.localStorage.getItem('mapData'));
+      const data = getMapData()
       if(!data){
         alert("No Data stored");
       }else{
@@ -368,33 +367,30 @@ function deleteFuncData(name){
   }
 }
 
-// Returns the Map data of ExWebThrottle
+/**
+ * Returns the Map data of ExWebThrottle
+ * @return {[]}
+ */
 function getMapData(){
-  if (typeof Storage !== "undefined") {
-    return JSON.parse(window.localStorage.getItem("mapData"));
-  } else {
+  if (typeof Storage === "undefined") {
     return [];
   }
+
+  const localMapData = JSON.parse(window.localStorage.getItem("mapData"));
+
+  return localMapData || []
 }
 
 // Returns boolen if the given Map exists in local storage
-function ifExists(name){
-  data = JSON.parse(window.localStorage.getItem('mapData'));
-  found = false;
-  if(data != null){
-    data.find(function(item, i){
-      if(item.mname == name){
-        found = true;
-      }
-    });
-    return found;
-  }
-  return found;
+function ifExists(name) {
+  const data = getMapData()
+  const existingItem = data.find((item) => item.mname === name);
+  return !!existingItem;
 }
 
 //Download all Maps of EXthrottle
 function exportMapData() {
-  data = window.localStorage.getItem('mapData');
+  const data = getMapData()
   const a = document.createElement("a");
   const file = new Blob([data], {type: 'application/json'});
   a.href = URL.createObjectURL(file);
@@ -549,12 +545,12 @@ function importPrefData(data) {
 }
 
 function exportAppData(){
-  jsonObj = [
+  const jsonObj = [
     {maps: getMapData()},
     {locos: getLocoList()},
     {preferences: getUserPreferences()}
   ]
-  data = JSON.stringify(jsonObj);
+  const data = JSON.stringify(jsonObj);
   const a = document.createElement("a");
   const file = new Blob([data], { type: "application/json" });
   a.href = URL.createObjectURL(file);


### PR DESCRIPTION
### What?

I have added/removed/altered:
- [x] Refactored `getMapData()`
- [x] Replaced `JSON.parse(window.localStorage.getItem('mapData')` with `getMapData()`
- [x] Added `const` to methods

### Why?

I am doing this because:
- `getMapData` would return `undefined` the if no maps had been stored locally.
- The autocomplete on the map select was failing when `undefined` was returned.
- Additional `const`s were added to ensure variables were being scoped to their functions.

### Acceptance Criteria

I can call this done when:
- [x] Map autocomplete does not fail to load

### Deployment risks
- All new code has been written using `ES6` syntax. This is widely [supported](https://caniuse.com/?search=es6) by modern browsers.