### PR TITLE
Fixes communication with CS

### DIFF
--- a/js/commandController.js
+++ b/js/commandController.js
@@ -111,6 +111,7 @@ function writeToStream(...lines) {
       stream.write(packet)
       console.log(packet)
   });
+  stream.releaseLock();
 }
 
 // Transformer for the Web Serial API. Data comes in as a stream so we

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -135,6 +135,10 @@ class Emulator {
       return turnoutEmulator.turnouts
     }
   }
+
+  // Prevents a type error during runtime
+  releaseLock() {
+  }
 }
 
 class TurnoutEmulator {


### PR DESCRIPTION
Since v1.3.2, WebThrottle communication with the CS has been broken as reported in #77.
This is fixed by this PR.