### PR TITLE
Fix direction toggle on translated pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,9 +193,9 @@
                                             </button>
                                         </div>
                                         <div class="dir-toggle">
-                                            <button class="dir-btn forward selected" id="dir-f" aria-label="forward" ><span class="arrow-up icon-up"></span></button>
+                                            <button class="dir-btn forward selected" id="dir-f" data-direction="forward" aria-label="forward" ><span class="arrow-up icon-up"></span></button>
                                             <!-- <button class="dir-btn stop" id="dir-S" aria-label="stop"> <span class="stop"></span></button> -->
-                                            <button class="dir-btn backward" id="dir-b" aria-label="backward"> <span class="arrow-down icon-down"></button>        
+                                            <button class="dir-btn backward" id="dir-b" data-direction="backward" aria-label="backward"> <span class="arrow-down icon-down"></button>        
                                         </div>
                                         <div class="em-btn">
                                             <button class="normal-stop" id="normal-stop" title="Stop">

--- a/js/exwebthrottle.js
+++ b/js/exwebthrottle.js
@@ -798,7 +798,7 @@ $(document).ready(function () {
     if (getCV() != 0) {
       current = $(this);
       lastDir = getDirection();
-      dir = current.attr("aria-label");
+      dir = current.attr("data-direction");
       $(".dir-btn").removeClass("selected");
       current.addClass("selected", 200);
       console.log(dir);


### PR DESCRIPTION
When using the browser page translation feature, aria-labels are changed to the new language and breaks the current logic.

The direction value used is now saved in a new `data-direction` attribute. (to spec https://html.spec.whatwg.org/#embedding-custom-non-visible-data-with-the-data-*-attributes)

Fixes #113